### PR TITLE
LoadFonts/LoadFontsFromDirectory does not exist in current. Changed t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ public partial class App : Application
   public App()
   {
     var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-    Fonts.FontAwesomeFonts.LoadFontsFromDirectory(Path.Combine(directory, "Fonts") + "/");      
+    FontAwesome6.Fonts.FontAwesomeFonts.LoadAllStyles(Path.Combine(directory, "Fonts") + "/");      
   }
 }
 ```
@@ -215,7 +215,7 @@ public partial class App : Application
 {
   public App()
   {
-    Fonts.FontAwesomeFonts.LoadFonts(new Uri("pack://application:,,,/Fonts/"));      
+    FontAwesome6.Fonts.FontAwesomeFonts.LoadAllStyles(new Uri("pack://application:,,,/Fonts/"));      
   }
 }
 ```


### PR DESCRIPTION
…o LoadAllStyles.

Just a documentation fix so that copy/paste will work. The example calls methods that do not exist or have been possibly renamed.
